### PR TITLE
Fix word wrap button title

### DIFF
--- a/components/pre.tsx
+++ b/components/pre.tsx
@@ -68,7 +68,7 @@ export const Pre = ({
         <Button
           onClick={toggleWordWrap}
           className="md:nx-hidden"
-          title="Toggle word wrap elvis"
+          title="Toggle word wrap"
         >
           <WordWrapIcon className="nx-pointer-events-none nx-h-4 nx-w-4" />
         </Button>


### PR DESCRIPTION
## Summary
- correct the title text on the word wrap button

## Testing
- `npm run build` *(fails: `next` not found)*